### PR TITLE
Update Secrets and Roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ Cloud architecture diagram of the infrastructure created by this module.
 
 ## Variables
 
-| Name                            | Type        | Purpose                                                                                                                                           |
-|---------------------------------|-------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
-| _**https_trigger_lambda_name**_ | string      | Name of the lambda function created by the Module which services as an HTTPS endpoint.                                                            |
-| **_region_**                    | string      | AWS region into which resources should be deployed.                                                                                               |
-| **_service_account_name_**      | string      | Name of the service account with exclusively ECS Task invocation privileges that serves as the service account for compute created by the module. |
-| **_tags_**                      | map(string) | An optional mapping of tags to add to resources created by the module.                                                                            |
-
+| Name                           | Type        | Purpose                                                                                                                                           |
+|--------------------------------|-------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
+| **s3_state_bucket_name**_      | string      | Optional name of the S3 bucket used for storing Terraform state. The ECS Fargate task created by the module will have read access to this bucket. |
+| **https_trigger_lambda_name**_ | string      | Name of the lambda function created by the Module which services as an HTTPS endpoint.                                                            |
+| **_region_**                   | string      | AWS region into which resources should be deployed.                                                                                               |
+| **_service_account_name_**     | string      | Name of the service account with exclusively ECS Task invocation privileges that serves as the service account for compute created by the module. |
+| **_tags_**                     | map(string) | An optional mapping of tags to add to resources created by the module.                                                                            |
 
 ## How to Use this Module
 This module defines the compute resources needed to run dragondrop within your own cloud environment.
@@ -32,12 +32,13 @@ The ECS Fargate Task hosts dragondrop's proprietary container. All environment v
 to secrets within AWS Parameter Store, and can be customized like any other secret.
 
 ### Security When Using This Module
-This module creates a new IAM role, "dragondrop HTTPS Trigger Role" which has the minimum permissions needed to evoke
-the created Fargate Task. This role is assigned to a new service account, and that service account is the service account
-used by the Lambda function provisioned by this module.
+This module creates two new roles with minimized IAM permissions:
+1) "dragondrop-lambda-https-trigger" which has the minimum permissions needed to evoke the created Fargate Task.
+The Lambda function created by this module is granted [this role](./modules/lambda_https_endpoint/data.tf).
 
-Lastly, another service account is granted Secret Accessor privileges on only the secrets referenced by the Fargate task as
-environment variables, and used by the Fargate task to run the dragondrop engine.
+2) "dragondrop-fargate-runner", an IAM role with Secret Accessor privileges on only the secrets referenced by the Fargate task as
+environment variables. Also has read-only access to then entire AWS account, and optional read-access to the s3 bucket containing 
+Terraform state files. The ECS Fargate task created by this module is granted [this role](./modules/lambda_https_endpoint/).
 
 ## What is dragondrop.cloud?
 [dragondrop.cloud](https://dragondrop.cloud) is a provider of IAC automation solutions that are self-hosted

--- a/modules/ecs_fargate_iam_secrets/data.tf
+++ b/modules/ecs_fargate_iam_secrets/data.tf
@@ -18,22 +18,28 @@ data "aws_iam_policy_document" "secret_reader" {
     effect = "Allow"
     resources = [
       module.api_path_secret.arn,
-      module.division_cloud_credentials_secret.arn,
       module.vcs_token_secret.arn,
       module.terraform_cloud_token_secret.arn,
-      module.org_token_secret.arn,
-      module.infracost_api_token_secret.arn,
     ]
   }
 
   depends_on = [
     module.api_path_secret,
-    module.division_cloud_credentials_secret,
     module.vcs_token_secret,
     module.terraform_cloud_token_secret,
-    module.org_token_secret,
-    module.infracost_api_token_secret,
   ]
+}
+
+data "aws_iam_policy_document" "s3_state_bucket_reader" {
+  statement {
+    actions = [
+      "s3:GetObject",
+      "s3:GetObjectAcl",
+      "s3:ListBucket",
+    ]
+    effect    = "Allow"
+    resources = ["arn:aws:s3:::${var.s3_state_bucket_name}/*"]
+  }
 }
 
 data "aws_iam_policy_document" "ecs_task_assume_role_policy" {

--- a/modules/ecs_fargate_iam_secrets/variables.tf
+++ b/modules/ecs_fargate_iam_secrets/variables.tf
@@ -8,6 +8,11 @@ variable "log_creator_policy_name" {
   type        = string
 }
 
+variable "s3_state_bucket_name" {
+  description = "Optional name of the S3 bucket used for storing Terraform state. The ECS Fargate task created by the module will have read access to this bucket."
+  type        = string
+}
+
 variable "secret_reader_policy_name" {
   description = "Name of the secret_reader policy to create. Will be prefixed by 'dragondrop'."
   type        = string

--- a/modules/ecs_fargate_task/main.tf
+++ b/modules/ecs_fargate_task/main.tf
@@ -54,10 +54,6 @@ resource "aws_ecs_task_definition" "dragondrop_drift_task" {
         valueFrom = module.ecs_fargate_iam_secrets.api_path_secret_arn
       },
       {
-        name      = "CLOUDCONCIERGE_DIVISIONCLOUDCREDENTIALS"
-        valueFrom = module.ecs_fargate_iam_secrets.division_cloud_credentials_secret_arn
-      },
-      {
         name      = "CLOUDCONCIERGE_VCSTOKEN"
         valueFrom = module.ecs_fargate_iam_secrets.vcs_token_secret_arn
       },
@@ -65,14 +61,6 @@ resource "aws_ecs_task_definition" "dragondrop_drift_task" {
         name      = "CLOUDCONCIERGE_TERRAFORMCLOUDTOKEN"
         valueFrom = module.ecs_fargate_iam_secrets.terraform_cloud_token_secret_arn
       },
-      {
-        name      = "CLOUDCONCIERGE_ORGTOKEN"
-        valueFrom = module.ecs_fargate_iam_secrets.org_token_secret_arn
-      },
-      {
-        name      = "CLOUDCONCIERGE_INFRACOSTAPITOKEN"
-        valueFrom = module.ecs_fargate_iam_secrets.infracost_api_token_secret_arn
-      }
     ],
 
     logConfiguration = {

--- a/variables.tf
+++ b/variables.tf
@@ -35,6 +35,12 @@ variable "task_memory" {
   default     = 8192
 }
 
+variable "s3_state_bucket_name" {
+  description = "Optional name of the S3 bucket used for storing Terraform state. The ECS Fargate task created by the module will have read access to this bucket."
+  type        = string
+  default     = "NONE"
+}
+
 # Required variables for module
 variable "https_trigger_lambda_name" {
   description = "Name of the https trigger lambda that will trigger the dragondrop 'engine' hosted in an ECS Fargate task."


### PR DESCRIPTION
- Remove all unneeded secret values
- Add default read-only role to the ECS Fargate task, eliminate need for static, hard-coded credentials as an environment variable